### PR TITLE
add diagrams to ssp demo content

### DIFF
--- a/system-security-plans/ssp-example.json
+++ b/system-security-plans/ssp-example.json
@@ -1,443 +1,573 @@
 {
-  "system-security-plan" : {
-    "uuid" : "cff8385f-108e-40a5-8f7a-82f3dc0eaba8",
-    "metadata" : {
-      "title" : "Enterprise Logging and Auditing System Security Plan",
-      "last-modified" : "2022-07-01T15:59:01.309675Z",
-      "version" : "1.0",
-      "oscal-version" : "1.0.0",
-      "roles" : [ {
-        "id" : "legal-officer",
-        "title" : "Legal Officer"
-      } ],
-      "parties" : [ {
-        "uuid" : "3b2a5599-cc37-403f-ae36-5708fa804b27",
-        "type" : "organization",
-        "name" : "Enterprise Asset Owners"
-      }, {
-        "uuid" : "833ac398-5c9a-4e6b-acba-2a9c11399da0",
-        "type" : "organization",
-        "name" : "Enterprise Asset Administrators"
-      }, {
-        "uuid" : "ec485dcf-2519-43f5-8e7d-014cc315332d",
-        "type" : "organization",
-        "name" : "Legal Department"
-      }, {
-        "uuid" : "0f0c15ed-565e-4ce9-8670-b54853d0bf03",
-        "type" : "organization",
-        "name" : "IT Department"
-      }, {
-        "uuid" : "96c362ee-a012-4e07-92f3-486ab303b0e7",
-        "type" : "organization",
-        "name" : "Acme Corp"
-      } ]
+  "system-security-plan": {
+    "uuid": "cff8385f-108e-40a5-8f7a-82f3dc0eaba8",
+    "metadata": {
+      "title": "Enterprise Logging and Auditing System Security Plan",
+      "last-modified": "2022-07-01T15:59:01.309675Z",
+      "version": "1.0",
+      "oscal-version": "1.0.0",
+      "roles": [
+        {
+          "id": "legal-officer",
+          "title": "Legal Officer"
+        }
+      ],
+      "parties": [
+        {
+          "uuid": "3b2a5599-cc37-403f-ae36-5708fa804b27",
+          "type": "organization",
+          "name": "Enterprise Asset Owners"
+        },
+        {
+          "uuid": "833ac398-5c9a-4e6b-acba-2a9c11399da0",
+          "type": "organization",
+          "name": "Enterprise Asset Administrators"
+        },
+        {
+          "uuid": "ec485dcf-2519-43f5-8e7d-014cc315332d",
+          "type": "organization",
+          "name": "Legal Department"
+        },
+        {
+          "uuid": "0f0c15ed-565e-4ce9-8670-b54853d0bf03",
+          "type": "organization",
+          "name": "IT Department"
+        },
+        {
+          "uuid": "96c362ee-a012-4e07-92f3-486ab303b0e7",
+          "type": "organization",
+          "name": "Acme Corp"
+        }
+      ]
     },
-    "import-profile" : {
-      "href" : "https://raw.githubusercontent.com/usnistgov/oscal-content/v1.0.0/nist.gov/SP800-53/rev4/json/NIST_SP-800-53_rev4_MODERATE-baseline_profile.json"
+    "import-profile": {
+      "href": "https://raw.githubusercontent.com/usnistgov/oscal-content/v1.0.0/nist.gov/SP800-53/rev4/json/NIST_SP-800-53_rev4_MODERATE-baseline_profile.json"
     },
-    "system-characteristics" : {
-      "system-ids" : [ {
-        "identifier-type" : "https://ietf.org/rfc/rfc4122",
-        "id" : "d7456980-9277-4dcb-83cf-f8ff0442623b"
-      } ],
-      "system-name" : "Enterprise Logging and Auditing System",
-      "description" : "This is an example of a system that provides enterprise logging and log auditing capabilities.",
-      "props" : [ {
-        "name" : "deployment-model",
-        "value" : "private"
-      }, {
-        "name" : "service-models",
-        "value" : "iaas"
-      } ],
-      "security-sensitivity-level" : "moderate",
-      "system-information" : {
-        "information-types" : [ {
-          "uuid" : "7d28ac6e-5970-4f4c-a508-5a3715f0f02b",
-          "title" : "System and Network Monitoring",
-          "description" : "This system maintains historical logging and auditing information for all client devices connected to this system.",
-          "categorizations" : [ {
-            "system" : "https://doi.org/10.6028/NIST.SP.800-60v2r1",
-            "information-type-ids" : [ "C.3.5.8" ]
-          } ],
-          "confidentiality-impact" : {
-            "base" : "fips-199-moderate"
-          },
-          "integrity-impact" : {
-            "base" : "fips-199-moderate"
-          },
-          "availability-impact" : {
-            "base" : "fips-199-low"
+    "system-characteristics": {
+      "system-name": "Enterprise Logging and Auditing System",
+      "description": "This is an example of a system that provides enterprise logging and log auditing capabilities.",
+      "system-ids": [
+        {
+          "id": "d7456980-9277-4dcb-83cf-f8ff0442623b",
+          "identifier-type": "https://ietf.org/rfc/rfc4122"
+        }
+      ],
+      "security-sensitivity-level": "moderate",
+      "system-information": {
+        "information-types": [
+          {
+            "uuid": "7d28ac6e-5970-4f4c-a508-5a3715f0f02b",
+            "title": "System and Network Monitoring",
+            "categorizations": [
+              {
+                "system": "https://doi.org/10.6028/NIST.SP.800-60v2r1",
+                "information-type-ids": ["C.3.5.8"]
+              }
+            ],
+            "description": "This system maintains historical logging and auditing information for all client devices connected to this system.",
+            "confidentiality-impact": {"base": "fips-199-moderate"},
+            "integrity-impact": {"base": "fips-199-moderate"},
+            "availability-impact": {"base": "fips-199-low"}
           }
-        } ]
+        ]
       },
-      "security-impact-level" : {
-        "security-objective-confidentiality" : "fips-199-moderate",
-        "security-objective-integrity" : "fips-199-moderate",
-        "security-objective-availability" : "fips-199-low"
+      "security-impact-level": {
+        "security-objective-confidentiality": "fips-199-moderate",
+        "security-objective-integrity": "fips-199-moderate",
+        "security-objective-availability": "fips-199-low"
       },
-      "status" : {
-        "state" : "other",
-        "remarks" : "This is an example, and is not intended to be implemented as a system"
+      "status": {
+        "state": "other",
+        "remarks": "This is an example, and is not intended to be implemented as a system"
       },
-      "authorization-boundary" : {
-        "description" : "The description of the authorization boundary would go here.",
-        "diagrams" : [ {
-          "uuid" : "bde155b3-6973-4bc7-9aa4-a4f6803968eb",
-          "description" : "A diagram-specific explanation.",
-          "links" : [ {
-            "href" : "#a2fc103a-9fe6-433d-a83b-44a33db1564b",
-            "rel" : "diagram"
-          } ],
-          "caption" : "Authorization Boundary Diagram"
-        } ]
+      "props": [
+        {
+          "name": "deployment-model",
+          "value": "private"
+        },
+        {
+          "name": "service-models",
+          "value": "iaas"
+        }
+      ],
+      "authorization-boundary": {
+        "description": "The description of the authorization boundary would go here.",
+        "diagrams": [
+          {
+            "uuid": "bde155b3-6973-4bc7-9aa4-a4f6803968eb",
+            "description": "A diagram-specific explanation.",
+            "links": [
+              {
+                "href": "#a2fc103a-9fe6-433d-a83b-44a33db1564b",
+                "rel": "diagram"
+              }
+            ],
+            "caption": "Authorization Boundary Diagram"
+          }
+        ]
       },
-      "network-architecture" : {
-        "description" : "The system network architecture",
-        "diagrams" : [ {
-          "uuid" : "7afc375f-de44-452a-a7d2-d38c76713fa5",
-          "description" : "Client devices connect to switches which connect to a router which connects to the internet",
-          "links" : [ {
-            "href" : "#e9a5474b-3d71-42df-9e38-f490407336c2",
-            "rel" : "diagram"
-          } ],
-          "caption" : "Network Architecture Diagram"
-        }, {
-          "uuid" : "c7bb2b50-25ca-44db-92eb-e5fca20df751",
-          "description" : "Another sample network architecture",
-          "links" : [ {
-            "href" : "#d3ffc03c-bf2d-4955-90cd-075687ed669a",
-            "rel" : "diagram"
-          } ],
-          "caption" : "Sample network diagram"
-        } ]
+      "network-architecture": {
+        "description": "The system network architecture",
+        "diagrams": [
+          {
+            "uuid": "7afc375f-de44-452a-a7d2-d38c76713fa5",
+            "description": "Client devices connect to switches which connect to a router which connects to the internet",
+            "links": [
+              {
+                "href": "#e9a5474b-3d71-42df-9e38-f490407336c2",
+                "rel": "diagram"
+              }
+            ],
+            "caption": "Network Architecture Diagram"
+          },
+          {
+            "uuid": "c7bb2b50-25ca-44db-92eb-e5fca20df751",
+            "description": "Another sample network architecture",
+            "links": [
+              {
+                "href": "#d3ffc03c-bf2d-4955-90cd-075687ed669a",
+                "rel": "diagram"
+              }
+            ],
+            "caption": "Sample network diagram"
+          }
+        ]
       },
-      "data-flow" : {
-        "description" : "The system data flow",
-        "diagrams" : [ {
-          "uuid" : "39da80c2-dce7-44e3-971d-b44702e5e9cf",
-          "description" : "Data flows throughout the system",
-          "links" : [ {
-            "href" : "#5cfbc4f7-b7f0-4218-b457-ce04c805e2c9",
-            "rel" : "diagram"
-          } ],
-          "caption" : "Data Flow Diagram"
-        } ]
+      "data-flow": {
+        "description": "The system data flow",
+        "diagrams": [
+          {
+            "uuid": "39da80c2-dce7-44e3-971d-b44702e5e9cf",
+            "description": "Data flows throughout the system",
+            "links": [
+              {
+                "href": "#5cfbc4f7-b7f0-4218-b457-ce04c805e2c9",
+                "rel": "diagram"
+              }
+            ],
+            "caption": "Data Flow Diagram"
+          }
+        ]
       }
     },
-    "system-implementation" : {
-      "users" : [ {
-        "uuid" : "9824089b-322c-456f-86c4-4111c4200f69",
-        "title" : "System Administrator",
-        "props" : [ {
-          "name" : "type",
-          "value" : "internal"
-        } ],
-        "role-ids" : [ "asset-administrator" ]
-      }, {
-        "uuid" : "ae8de94c-835d-4303-83b1-114b6a117a07",
-        "title" : "Audit Team",
-        "props" : [ {
-          "name" : "type",
-          "value" : "internal"
-        } ],
-        "role-ids" : [ "asset-owner" ]
-      }, {
-        "uuid" : "372ce7a3-92b0-437e-a98c-24d29f9bfab8",
-        "title" : "Legal Department",
-        "props" : [ {
-          "name" : "type",
-          "value" : "internal"
-        } ],
-        "role-ids" : [ "legal-officer" ]
-      } ],
-      "components" : [ {
-        "uuid" : "e00acdcf-911b-437d-a42f-b0b558cc4f03",
-        "type" : "software",
-        "title" : "Logging Server",
-        "description" : "Provides a means for hosts to publish logged events to a central server.",
-        "status" : {
-          "state" : "operational"
+    "system-implementation": {
+      "remarks": "This is a partial implementation that addresses the logging server portion of the auditing system.",
+      "users": [
+        {
+          "uuid": "9824089b-322c-456f-86c4-4111c4200f69",
+          "title": "System Administrator",
+          "role-ids": ["asset-administrator"],
+          "props": [
+            {
+              "name": "type",
+              "value": "internal"
+            }
+          ]
         },
-        "responsible-roles" : [ {
-          "role-id" : "provider",
-          "party-uuids" : [ "96c362ee-a012-4e07-92f3-486ab303b0e7" ]
-        }, {
-          "role-id" : "asset-owner",
-          "party-uuids" : [ "3b2a5599-cc37-403f-ae36-5708fa804b27" ]
-        }, {
-          "role-id" : "asset-administrator",
-          "party-uuids" : [ "833ac398-5c9a-4e6b-acba-2a9c11399da0" ]
-        } ]
-      }, {
-        "uuid" : "795533ab-9427-4abe-820f-0b571bacfe6d",
-        "type" : "policy",
-        "title" : "Enterprise Logging, Monitoring, and Alerting Policy",
-        "description" : "Requires all components to send logs to the enterprise logging solution\n\n- Requires all components synchronize their time with the appropriate enterprise time service, and at what frequency.\n\n- Identifies the events that must be captured\n\n- Identifies who is responsible/accountable for performing these functions",
-        "props" : [ {
-          "name" : "version",
-          "value" : "2.1"
-        }, {
-          "name" : "last-modified-date",
-          "value" : "20181015"
-        } ],
-        "status" : {
-          "state" : "operational"
+        {
+          "uuid": "ae8de94c-835d-4303-83b1-114b6a117a07",
+          "title": "Audit Team",
+          "role-ids": ["asset-owner"],
+          "props": [
+            {
+              "name": "type",
+              "value": "internal"
+            }
+          ]
         },
-        "responsible-roles" : [ {
-          "role-id" : "maintainer",
-          "party-uuids" : [ "ec485dcf-2519-43f5-8e7d-014cc315332d" ]
-        } ]
-      }, {
-        "uuid" : "941e2a87-46f4-4b3e-9e87-bbd187091ca1",
-        "type" : "process",
-        "title" : "System Integration Process",
-        "description" : "Ensures proper integration into the enterprise as new systems are brought into production.",
-        "props" : [ {
-          "name" : "last-modified-date",
-          "value" : "20181015"
-        } ],
-        "links" : [ {
-          "href" : "#795533ab-9427-4abe-820f-0b571bacfe6d",
-          "rel" : "implements-policy",
-          "text" : "Ensures logs from components in new system are able to published to the logging server. Ensures log monitoring capabilities recognize new system as authorized."
-        } ],
-        "status" : {
-          "state" : "operational"
+        {
+          "uuid": "372ce7a3-92b0-437e-a98c-24d29f9bfab8",
+          "title": "Legal Department",
+          "role-ids": ["legal-officer"],
+          "props": [
+            {
+              "name": "type",
+              "value": "internal"
+            }
+          ]
+        }
+      ],
+      "components": [
+        {
+          "uuid": "e00acdcf-911b-437d-a42f-b0b558cc4f03",
+          "title": "Logging Server",
+          "description": "Provides a means for hosts to publish logged events to a central server.",
+          "status": { "state": "operational" },
+          "type": "software",
+          "responsible-roles": [
+            {
+              "role-id": "provider",
+              "party-uuids": ["96c362ee-a012-4e07-92f3-486ab303b0e7"]
+            },
+            {
+              "role-id": "asset-owner",
+              "party-uuids": ["3b2a5599-cc37-403f-ae36-5708fa804b27"]
+            },
+            {
+              "role-id": "asset-administrator",
+              "party-uuids": ["833ac398-5c9a-4e6b-acba-2a9c11399da0"]
+            }
+          ]
         },
-        "responsible-roles" : [ {
-          "role-id" : "maintainer",
-          "party-uuids" : [ "0f0c15ed-565e-4ce9-8670-b54853d0bf03" ]
-        } ]
-      }, {
-        "uuid" : "fa39eb84-3014-46b4-b6bc-7da10527c262",
-        "type" : "process",
-        "title" : "Inventory Management Process",
-        "description" : "Describes how new components are introduced into the system - ensures monitoring teams know about every asset that should be producing logs, thus should be monitored.",
-        "props" : [ {
-          "name" : "last-modified-date",
-          "value" : "20181015"
-        } ],
-        "links" : [ {
-          "href" : "#795533ab-9427-4abe-820f-0b571bacfe6d",
-          "rel" : "implements-policy",
-          "text" : "Ensures that all host are known and authorized. Ensures that these hosts publish log events to the logging server."
-        } ],
-        "status" : {
-          "state" : "operational"
+        {
+          "uuid": "795533ab-9427-4abe-820f-0b571bacfe6d",
+          "title": "Enterprise Logging, Monitoring, and Alerting Policy",
+          "type": "policy",
+          "description": "Requires all components to send logs to the enterprise logging solution\n\n- Requires all components synchronize their time with the appropriate enterprise time service, and at what frequency.\n\n- Identifies the events that must be captured\n\n- Identifies who is responsible/accountable for performing these functions",
+          "status": {"state": "operational"},
+          "props": [
+            {
+              "name": "version",
+              "value": "2.1"
+            },
+            {
+              "name": "last-modified-date",
+              "value": "20181015"
+            }
+          ],
+          "responsible-roles": [
+            {
+              "role-id": "maintainer",
+              "party-uuids": ["ec485dcf-2519-43f5-8e7d-014cc315332d"]
+            }
+          ]
         },
-        "responsible-roles" : [ {
-          "role-id" : "maintainer",
-          "party-uuids" : [ "0f0c15ed-565e-4ce9-8670-b54853d0bf03" ]
-        } ]
-      }, {
-        "uuid" : "4938767c-dd8b-4ea4-b74a-fafffd48ac99",
-        "type" : "guidance",
-        "title" : "Configuration Management Guidance",
-        "description" : "Describes how to configure a component to ensure its logs are transmitted to Splunk in the appropriate format. Also describes how to configure time synchronization.",
-        "props" : [ {
-          "name" : "last-modified-date",
-          "value" : "20181015"
-        } ],
-        "links" : [ {
-          "href" : "#795533ab-9427-4abe-820f-0b571bacfe6d",
-          "rel" : "implements-policy",
-          "text" : "Ensures that all host are configured to publish log events to the logging server."
-        } ],
-        "status" : {
-          "state" : "operational"
+        {
+          "uuid": "941e2a87-46f4-4b3e-9e87-bbd187091ca1",
+          "title": "System Integration Process",
+          "type": "process",
+          "description": "Ensures proper integration into the enterprise as new systems are brought into production.",
+          "status": {"state": "operational"},
+          "props": [
+            {
+              "name": "last-modified-date",
+              "value": "20181015"
+            }
+          ],
+          "responsible-roles": [
+            {
+              "role-id": "maintainer",
+              "party-uuids": ["0f0c15ed-565e-4ce9-8670-b54853d0bf03"]
+            }
+          ],
+          "links": [
+            {
+              "rel": "implements-policy",
+              "href": "#795533ab-9427-4abe-820f-0b571bacfe6d",
+              "text": "Ensures logs from components in new system are able to published to the logging server. Ensures log monitoring capabilities recognize new system as authorized."
+            }
+          ]
         },
-        "responsible-roles" : [ {
-          "role-id" : "maintainer",
-          "party-uuids" : [ "0f0c15ed-565e-4ce9-8670-b54853d0bf03" ]
-        } ]
-      } ],
-      "inventory-items" : [ {
-        "uuid" : "c9c32657-a0eb-4cf2-b5c1-20928983063c",
-        "description" : "The logging server.",
-        "props" : [ {
-          "name" : "asset-id",
-          "value" : "asset-id-logging-server"
-        } ],
-        "responsible-parties" : [ {
-          "role-id" : "asset-administrator",
-          "party-uuids" : [ "833ac398-5c9a-4e6b-acba-2a9c11399da0" ]
-        }, {
-          "role-id" : "asset-owner",
-          "party-uuids" : [ "3b2a5599-cc37-403f-ae36-5708fa804b27" ]
-        } ],
-        "implemented-components" : [ {
-          "component-uuid" : "e00acdcf-911b-437d-a42f-b0b558cc4f03"
-        }, {
-          "component-uuid" : "795533ab-9427-4abe-820f-0b571bacfe6d"
-        } ]
-      } ],
-      "remarks" : "This is a partial implementation that addresses the logging server portion of the auditing system."
+        {
+          "uuid": "fa39eb84-3014-46b4-b6bc-7da10527c262",
+          "title": "Inventory Management Process",
+          "type": "process",
+          "description": "Describes how new components are introduced into the system - ensures monitoring teams know about every asset that should be producing logs, thus should be monitored.",
+          "status": {"state": "operational"},
+          "props": [
+            {
+              "name": "last-modified-date",
+              "value": "20181015"
+            }
+          ],
+          "responsible-roles": [
+            {
+              "role-id": "maintainer",
+              "party-uuids": ["0f0c15ed-565e-4ce9-8670-b54853d0bf03"]
+            }
+          ],
+          "links": [
+            {
+              "rel": "implements-policy",
+              "href": "#795533ab-9427-4abe-820f-0b571bacfe6d",
+              "text": "Ensures that all host are known and authorized. Ensures that these hosts publish log events to the logging server."
+            }
+          ]
+        },
+        {
+          "uuid": "4938767c-dd8b-4ea4-b74a-fafffd48ac99",
+          "title": "Configuration Management Guidance",
+          "type": "guidance",
+          "description": "Describes how to configure a component to ensure its logs are transmitted to Splunk in the appropriate format. Also describes how to configure time synchronization.",
+          "status": {"state": "operational"},
+          "props": [
+            {
+              "name": "last-modified-date",
+              "value": "20181015"
+            }
+          ],
+          "responsible-roles": [
+            {
+              "role-id": "maintainer",
+              "party-uuids": ["0f0c15ed-565e-4ce9-8670-b54853d0bf03"]
+            }
+          ],
+          "links": [
+            {
+              "rel": "implements-policy",
+              "href": "#795533ab-9427-4abe-820f-0b571bacfe6d",
+              "text": "Ensures that all host are configured to publish log events to the logging server."
+            }
+          ]
+        }
+      ],
+      "inventory-items": [
+        {
+          "uuid": "c9c32657-a0eb-4cf2-b5c1-20928983063c",
+          "description": "The logging server.",
+          "props": [
+            {
+              "name": "asset-id",
+              "value": "asset-id-logging-server"
+            }
+          ],
+          "responsible-parties": [
+            {
+              "role-id": "asset-administrator",
+              "party-uuids": ["833ac398-5c9a-4e6b-acba-2a9c11399da0"]
+            },
+            {
+              "role-id": "asset-owner",
+              "party-uuids": ["3b2a5599-cc37-403f-ae36-5708fa804b27"]
+            }
+          ],
+          "implemented-components": [
+            {"component-uuid": "e00acdcf-911b-437d-a42f-b0b558cc4f03"},
+            {"component-uuid": "795533ab-9427-4abe-820f-0b571bacfe6d"}
+          ]
+        }
+      ]
     },
-    "control-implementation" : {
-      "description" : "This is the control implementation for the system.",
-      "implemented-requirements" : [ {
-        "uuid" : "aaadb3ff-6ae8-4332-92db-211468c52af2",
-        "control-id" : "au-1",
-        "statements" : [ {
-          "statement-id" : "au-1_smt",
-          "uuid" : "7ad47329-dc55-4196-a19d-178a8fe7438d"
-        }, {
-          "statement-id" : "au-1_smt.a",
-          "uuid" : "f3887a91-9ed3-425c-b305-21e4634a1c34",
-          "by-components" : [ {
-            "component-uuid" : "795533ab-9427-4abe-820f-0b571bacfe6d",
-            "uuid" : "a74681b2-fbcb-46eb-90fd-0d55aa74ac7b",
-            "description" : "The legal department develops, documents and disseminates this policy to all staff and contractors within the organization.",
-            "set-parameters" : [ {
-              "param-id" : "au-1_prm_1",
-              "values" : [ "all staff and contractors within the organization" ]
-            } ]
-          }, {
-            "component-uuid" : "941e2a87-46f4-4b3e-9e87-bbd187091ca1",
-            "uuid" : "4f873ce6-dd49-4a46-bd4a-5041c22665f1",
-            "description" : "The IT department created and maintains this procedure. This department disseminates it to all IT staff who administer this system when the staff member is assigned and annually through training.",
-            "set-parameters" : [ {
-              "param-id" : "au-1_prm_1",
-              "values" : [ "all IT staff who administer this system when the staff member is assigned and annually through training" ]
-            } ]
-          }, {
-            "component-uuid" : "fa39eb84-3014-46b4-b6bc-7da10527c262",
-            "uuid" : "ea85a624-cd21-4c63-abe0-f66087e97241",
-            "description" : "The IT department created and maintains this procedure. This department disseminates it to all IT staff who administer this system when the staff member is assigned and annually through training.",
-            "set-parameters" : [ {
-              "param-id" : "au-1_prm_1",
-              "values" : [ "all IT staff who administer this system when the staff member is assigned and annually through training" ]
-            } ]
-          }, {
-            "component-uuid" : "4938767c-dd8b-4ea4-b74a-fafffd48ac99",
-            "uuid" : "b5e5823a-844f-4306-a5ab-7e110679e0d5",
-            "description" : "The IT department created and maintains this procedure. This department disseminates it to all IT staff who administer this system when the staff member is assigned and annually through training.",
-            "set-parameters" : [ {
-              "param-id" : "au-1_prm_1",
-              "values" : [ "all IT staff who administer this system when the staff member is assigned and annually through training" ]
-            } ]
-          } ]
-        }, {
-          "statement-id" : "au-1_smt.a.1",
-          "uuid" : "6fe632bd-33aa-4eea-a507-a37f0d212085",
-          "by-components" : [ {
-            "component-uuid" : "795533ab-9427-4abe-820f-0b571bacfe6d",
-            "uuid" : "2d0a7b08-da7f-4691-b99c-8fd9df02b25c",
-            "description" : "This policy explicitly states the purpose and scope of the policy in Section 1. Roles and responsibilities are described in Section 2. This section also describes responsibilities for organizational coordination. Management commitment and compliance statements are made in the board’s directive memo dated January 1, 2012."
-          } ]
-        }, {
-          "statement-id" : "au-1_smt.a.2",
-          "uuid" : "dbe9af68-1cd9-4ff1-965b-8f887351d411",
-          "by-components" : [ {
-            "component-uuid" : "941e2a87-46f4-4b3e-9e87-bbd187091ca1",
-            "uuid" : "dd4fd380-7a2a-4fba-9e98-933ba5cfc04d",
-            "description" : "This process aligns with the enterprise Logging, Monitoring, and Alerting Policy, Version 2.1, October 15, 2018. The following processes work together to fully implement the policy: System Integration Process, Inventory Management Process, Configuration Management, Log Review Process, and Monitoring and Alerting Process"
-          }, {
-            "component-uuid" : "fa39eb84-3014-46b4-b6bc-7da10527c262",
-            "uuid" : "3b912d0f-2463-497c-8d8a-72416f38e999",
-            "description" : "This process aligns with the enterprise Logging, Monitoring, and Alerting Policy, Version 2.1, October 15, 2018. The following processes work together to fully implement the policy: System Integration Process, Inventory Management Process, Configuration Management, Log Review Process, and Monitoring and Alerting Process"
-          }, {
-            "component-uuid" : "4938767c-dd8b-4ea4-b74a-fafffd48ac99",
-            "uuid" : "226ee2a2-cbdb-498f-8182-94dfa013476c",
-            "description" : "This process aligns with the enterprise Logging, Monitoring, and Alerting Policy, Version 2.1, October 15, 2018. The following processes work together to fully implement the policy: System Integration Process, Inventory Management Process, Configuration Management, Log Review Process, and Monitoring and Alerting Process"
-          } ]
-        }, {
-          "statement-id" : "au-1_smt.b",
-          "uuid" : "b1773cd6-afc5-4c87-84a7-f182e6be5af9",
-          "remarks" : "N/A"
-        }, {
-          "statement-id" : "au-1_smt.b.1",
-          "uuid" : "75873308-f37d-4e89-9c27-29f3dee4b314",
-          "by-components" : [ {
-            "component-uuid" : "795533ab-9427-4abe-820f-0b571bacfe6d",
-            "uuid" : "23903c59-1327-46f0-9c28-09ec7f144214",
-            "description" : "The legal department reviews this policy annually, and other times as necessary in response to regulatory or organizational changes. The legal department updates the policy as needed based on these reviews.",
-            "set-parameters" : [ {
-              "param-id" : "au-1_prm_2",
-              "values" : [ "annually, and other times as necessary in response to regulatory or organizational changes" ]
-            } ]
-          } ]
-        }, {
-          "statement-id" : "au-1_smt.b.2",
-          "uuid" : "74b5b0f2-9915-4f80-b7cd-379566442ab6",
-          "by-components" : [ {
-            "component-uuid" : "941e2a87-46f4-4b3e-9e87-bbd187091ca1",
-            "uuid" : "0c45b6e2-f85b-4656-a6cc-2a302d184720",
-            "description" : "The IT department reviews this process annually, and other times as necessary in response to regulatory or organizational changes. The IT department updates the policy as needed based on these reviews.",
-            "set-parameters" : [ {
-              "param-id" : "au-1_prm_3",
-              "values" : [ "annually, and other times as necessary in response to regulatory or organizational changes" ]
-            } ]
-          }, {
-            "component-uuid" : "fa39eb84-3014-46b4-b6bc-7da10527c262",
-            "uuid" : "094f02ce-4b7a-405c-90a5-ab4d95133f74",
-            "description" : "The IT department reviews this process annually, and other times as necessary in response to regulatory or organizational changes. The IT department updates the policy as needed based on these reviews.",
-            "set-parameters" : [ {
-              "param-id" : "au-1_prm_3",
-              "values" : [ "annually, and other times as necessary in response to regulatory or organizational changes" ]
-            } ]
-          }, {
-            "component-uuid" : "4938767c-dd8b-4ea4-b74a-fafffd48ac99",
-            "uuid" : "7ec8b7ec-d931-4055-ac74-6d288d636787",
-            "description" : "The IT department reviews this process annually, and other times as necessary in response to regulatory or organizational changes. The IT department updates the policy as needed based on these reviews",
-            "set-parameters" : [ {
-              "param-id" : "au-1_prm_3",
-              "values" : [ "annually, and other times as necessary in response to regulatory or organizational changes" ]
-            } ]
-          } ]
-        } ]
-      }, {
-        "uuid" : "1f78083c-0dab-4068-a1f8-02a2b61e0458",
-        "control-id" : "ac-2",
-        "statements" : [ {
-          "statement-id" : "ac-2.2_smt",
-          "uuid" : "a0e3f96d-308d-42ad-a8a3-baad92e6f601",
-          "by-components" : [ {
-            "component-uuid": "795533ab-9427-4abe-820f-0b571bacfe6d",
-            "uuid" : "75c54953-7436-4041-8c48-c926a2ebf5f3",
-            "description" : "example description",
-            "set-parameters" : [ {
-              "param-id" : "ac-2.2_prm_1",
-              "values" : [ "removes" ]
-            } ]
-          } ]
-        } ]
-      } ]
+    "control-implementation": {
+      "description": "This is the control implementation for the system.",
+      "implemented-requirements": [
+        {
+          "uuid": "aaadb3ff-6ae8-4332-92db-211468c52af2",
+          "control-id": "au-1",
+          "statements": [
+            {
+              "statement-id": "au-1_smt",
+              "uuid": "7ad47329-dc55-4196-a19d-178a8fe7438d"
+            },
+            {
+              "statement-id": "au-1_smt.a",
+              "uuid": "f3887a91-9ed3-425c-b305-21e4634a1c34",
+              "by-components": [
+                {
+                  "component-uuid": "795533ab-9427-4abe-820f-0b571bacfe6d",
+                  "uuid": "a74681b2-fbcb-46eb-90fd-0d55aa74ac7b",
+                  "description": "The legal department develops, documents and disseminates this policy to all staff and contractors within the organization.",
+                  "set-parameters": [
+                    {
+                      "param-id": "au-1_prm_1",
+                      "values": ["all staff and contractors within the organization"]
+                    }
+                  ]
+                },
+                {
+                  "component-uuid": "941e2a87-46f4-4b3e-9e87-bbd187091ca1",
+                  "uuid": "4f873ce6-dd49-4a46-bd4a-5041c22665f1",
+                  "description": "The IT department created and maintains this procedure. This department disseminates it to all IT staff who administer this system when the staff member is assigned and annually through training.",
+                  "set-parameters": [
+                    {
+                      "param-id": "au-1_prm_1",
+                      "values": ["all IT staff who administer this system when the staff member is assigned and annually through training"]
+                    }
+                  ]
+                },
+                {
+                  "component-uuid": "fa39eb84-3014-46b4-b6bc-7da10527c262",
+                  "uuid": "ea85a624-cd21-4c63-abe0-f66087e97241",
+                  "description": "The IT department created and maintains this procedure. This department disseminates it to all IT staff who administer this system when the staff member is assigned and annually through training.",
+                  "set-parameters": [
+                    {
+                      "param-id": "au-1_prm_1",
+                      "values": ["all IT staff who administer this system when the staff member is assigned and annually through training"]
+                    }
+                  ]
+                },
+                {
+                  "component-uuid": "4938767c-dd8b-4ea4-b74a-fafffd48ac99",
+                  "uuid": "b5e5823a-844f-4306-a5ab-7e110679e0d5",
+                  "description": "The IT department created and maintains this procedure. This department disseminates it to all IT staff who administer this system when the staff member is assigned and annually through training.",
+                  "set-parameters": [
+                    {
+                      "param-id": "au-1_prm_1",
+                      "values": ["all IT staff who administer this system when the staff member is assigned and annually through training"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "statement-id": "au-1_smt.a.1",
+              "uuid": "6fe632bd-33aa-4eea-a507-a37f0d212085",
+              "by-components": [
+                {
+                  "component-uuid": "795533ab-9427-4abe-820f-0b571bacfe6d",
+                  "uuid": "2d0a7b08-da7f-4691-b99c-8fd9df02b25c",
+                  "description": "This policy explicitly states the purpose and scope of the policy in Section 1. Roles and responsibilities are described in Section 2. This section also describes responsibilities for organizational coordination. Management commitment and compliance statements are made in the board’s directive memo dated January 1, 2012."
+                }
+              ]
+            },
+            {
+              "statement-id": "au-1_smt.a.2",
+              "uuid": "dbe9af68-1cd9-4ff1-965b-8f887351d411",
+              "by-components": [
+                {
+                  "component-uuid": "941e2a87-46f4-4b3e-9e87-bbd187091ca1",
+                  "uuid": "dd4fd380-7a2a-4fba-9e98-933ba5cfc04d",
+                  "description": "This process aligns with the enterprise Logging, Monitoring, and Alerting Policy, Version 2.1, October 15, 2018. The following processes work together to fully implement the policy: System Integration Process, Inventory Management Process, Configuration Management, Log Review Process, and Monitoring and Alerting Process"
+                },
+                {
+                  "component-uuid": "fa39eb84-3014-46b4-b6bc-7da10527c262",
+                  "uuid": "3b912d0f-2463-497c-8d8a-72416f38e999",
+                  "description": "This process aligns with the enterprise Logging, Monitoring, and Alerting Policy, Version 2.1, October 15, 2018. The following processes work together to fully implement the policy: System Integration Process, Inventory Management Process, Configuration Management, Log Review Process, and Monitoring and Alerting Process"
+                },
+                {
+                  "component-uuid": "4938767c-dd8b-4ea4-b74a-fafffd48ac99",
+                  "uuid": "226ee2a2-cbdb-498f-8182-94dfa013476c",
+                  "description": "This process aligns with the enterprise Logging, Monitoring, and Alerting Policy, Version 2.1, October 15, 2018. The following processes work together to fully implement the policy: System Integration Process, Inventory Management Process, Configuration Management, Log Review Process, and Monitoring and Alerting Process"
+                }
+              ]
+            },
+            {
+              "statement-id": "au-1_smt.b",
+              "uuid": "b1773cd6-afc5-4c87-84a7-f182e6be5af9",
+              "remarks": "N/A"
+            },
+            {
+              "statement-id": "au-1_smt.b.1",
+              "uuid": "75873308-f37d-4e89-9c27-29f3dee4b314",
+              "by-components": [
+                {
+                  "component-uuid": "795533ab-9427-4abe-820f-0b571bacfe6d",
+                  "uuid": "23903c59-1327-46f0-9c28-09ec7f144214",
+                  "set-parameters": [
+                    {
+                      "param-id": "au-1_prm_2",
+                      "values": [
+                        "annually, and other times as necessary in response to regulatory or organizational changes"
+                      ]
+                    }
+                  ],
+                  "description": "The legal department reviews this policy annually, and other times as necessary in response to regulatory or organizational changes. The legal department updates the policy as needed based on these reviews."
+                }
+              ]
+            },
+            {
+              "statement-id": "au-1_smt.b.2",
+              "uuid": "74b5b0f2-9915-4f80-b7cd-379566442ab6",
+              "by-components": [
+                {
+                  "component-uuid": "941e2a87-46f4-4b3e-9e87-bbd187091ca1",
+                  "uuid": "0c45b6e2-f85b-4656-a6cc-2a302d184720",
+                  "set-parameters": [
+                    {
+                      "param-id": "au-1_prm_3",
+                      "values": ["annually, and other times as necessary in response to regulatory or organizational changes"]
+                    }
+                  ],
+                  "description": "The IT department reviews this process annually, and other times as necessary in response to regulatory or organizational changes. The IT department updates the policy as needed based on these reviews."
+                },
+                {
+                  "component-uuid": "fa39eb84-3014-46b4-b6bc-7da10527c262",
+                  "uuid": "094f02ce-4b7a-405c-90a5-ab4d95133f74",
+                  "set-parameters": [
+                    {
+                      "param-id": "au-1_prm_3",
+                      "values": ["annually, and other times as necessary in response to regulatory or organizational changes"]
+                    }
+                  ],
+                  "description": "The IT department reviews this process annually, and other times as necessary in response to regulatory or organizational changes. The IT department updates the policy as needed based on these reviews."
+                },
+                {
+                  "component-uuid": "4938767c-dd8b-4ea4-b74a-fafffd48ac99",
+                  "uuid": "7ec8b7ec-d931-4055-ac74-6d288d636787",
+                  "set-parameters": [
+                    {
+                      "param-id": "au-1_prm_3",
+                      "values": ["annually, and other times as necessary in response to regulatory or organizational changes"]
+                    }
+                  ],
+                  "description": "The IT department reviews this process annually, and other times as necessary in response to regulatory or organizational changes. The IT department updates the policy as needed based on these reviews"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "uuid": "1f78083c-0dab-4068-a1f8-02a2b61e0458",
+          "control-id": "ac-2",
+          "statements": [
+            {
+              "statement-id": "ac-2.2_smt",
+              "uuid": "a0e3f96d-308d-42ad-a8a3-baad92e6f601",
+              "by-components": [
+                {
+                  "component-uuid": "795533ab-9427-4abe-820f-0b571bacfe6d",
+                  "uuid": "75c54953-7436-4041-8c48-c926a2ebf5f3",
+                  "description": "example description",
+                  "set-parameters": [
+                    {
+                      "param-id": "ac-2.2_prm_1",
+                      "values": ["removes"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
-    "back-matter" : {
-      "resources" : [ {
-        "uuid" : "a2fc103a-9fe6-433d-a83b-44a33db1564b",
-        "title" : "Some Diagram",
-        "description" : "This is a test diagram",
-        "rlinks" : [ {
-          "href" : "../resource-content/authz-boundary.png",
-          "media-type" : "image/png"
-        } ]
-      }, {
-        "uuid" : "e9a5474b-3d71-42df-9e38-f490407336c2",
-        "title" : "Network Architecture Diagram 1",
-        "description" : "A test network architecture diagram",
-        "rlinks" : [ {
-          "href" : "../resource-content/network-diagram.png",
-          "media-type" : "image/png"
-        } ]
-      }, {
-        "uuid" : "d3ffc03c-bf2d-4955-90cd-075687ed669a",
-        "title" : "Network Architecture Diagram 2",
-        "description" : "A test network architecture diagram",
-        "rlinks" : [ {
-          "href" : "https://upload.wikimedia.org/wikipedia/commons/1/12/Sample-network-diagram.png",
-          "media-type" : "image/png"
-        } ]
-      }, {
-        "uuid" : "5cfbc4f7-b7f0-4218-b457-ce04c805e2c9",
-        "title" : "Data Flow",
-        "description" : "A basic data flow diagram",
-        "rlinks" : [ {
-          "href" : "../resource-content/data-flow.png",
-          "media-type" : "image/png"
-        } ]
-      } ]
+    "back-matter": {
+      "resources": [
+        {
+          "uuid": "a2fc103a-9fe6-433d-a83b-44a33db1564b",
+          "title": "Some Diagram",
+          "description": "This is a test diagram",
+          "rlinks": [
+            {
+              "href": "../resource-content/authz-boundary.png",
+              "media-type": "image/png"
+            }
+          ]
+        },
+        {
+          "uuid": "e9a5474b-3d71-42df-9e38-f490407336c2",
+          "title": "Network Architecture Diagram 1",
+          "description": "A test network architecture diagram",
+          "rlinks": [
+            {
+              "href": "../resource-content/network-diagram.png",
+              "media-type": "image/png"
+            }
+          ]
+        },
+        {
+          "uuid": "d3ffc03c-bf2d-4955-90cd-075687ed669a",
+          "title": "Network Architecture Diagram 2",
+          "description": "A test network architecture diagram",
+          "rlinks": [
+            {
+              "href": "https://upload.wikimedia.org/wikipedia/commons/1/12/Sample-network-diagram.png",
+              "media-type": "image/png"
+            }
+          ]
+        },
+        {
+          "uuid": "5cfbc4f7-b7f0-4218-b457-ce04c805e2c9",
+          "title": "Data Flow",
+          "description": "A basic data flow diagram",
+          "rlinks": [
+            {
+              "href": "../resource-content/data-flow.png",
+              "media-type": "image/png"
+            }
+          ]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
The previous merge for the demo content in the ssp does not contain the diagrams it used to have. Update `ssp-example.json` so that they are displayed in the OSCAL Viewer.

Update any other demo content as necessary from NIST's demo content found <a href= "https://github.com/usnistgov/oscal-content"> here </a>