### PR TITLE
Reference the rev4 profile from `main` branch

### DIFF
--- a/system-security-plans/ssp-example.json
+++ b/system-security-plans/ssp-example.json
@@ -33,7 +33,7 @@
       } ]
     },
     "import-profile" : {
-      "href" : "https://raw.githubusercontent.com/usnistgov/oscal-content/v1.0.0/nist.gov/SP800-53/rev4/json/NIST_SP-800-53_rev4_MODERATE-baseline_profile.json"
+      "href" : "https://raw.githubusercontent.com/usnistgov/oscal-content/main/nist.gov/SP800-53/rev4/json/NIST_SP-800-53_rev4_MODERATE-baseline_profile.json"
     },
     "system-characteristics" : {
       "system-ids" : [ {


### PR DESCRIPTION
There has not been a release of the upstream `oscal-content` in awhile
but the fixes have been integrated. Using the main branch makes this
more consistent.
