### PR TITLE
chore: add schema validation in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "json.schemas": [
+        {
+            "fileMatch": ["catalogs/*.json"],
+            "url": "https://raw.githubusercontent.com/usnistgov/OSCAL/main/json/schema/oscal_catalog_schema.json"
+        },
+        {
+            "fileMatch": ["component-definitions/*.json"],
+            "url": "https://raw.githubusercontent.com/usnistgov/OSCAL/main/json/schema/oscal_component_schema.json"
+        },
+        {
+            "fileMatch": ["profiles/*.json"],
+            "url": "https://raw.githubusercontent.com/usnistgov/OSCAL/main/json/schema/oscal_profile_schema.json"
+        },
+        {
+            "fileMatch": ["system-security-plans/*.json"],
+            "url": "https://raw.githubusercontent.com/usnistgov/OSCAL/main/json/schema/oscal_ssp_schema.json"
+        }
+    ]
+}


### PR DESCRIPTION
This adds support for schema validation in VS Code (and other tools that
use its JSON language server). The underlying schema does not allow the
`$schema` field in objects so editor configuration is the best that we
can do. This makes sure to use the same schemas used in the pipeline.

For now, we follow the `main` branch of upstream but if more significant
changes start to occur between releases, we can switch to a tagged
version at any time.
